### PR TITLE
Release Staging version 0.2.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 # C extensions
 *.so
 
+# OS X files
+.DS_Store
+
 # Distribution / packaging
 .Python
 env/

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ uninstall-pifi: must_be_root
 	$(QUIET)$(ECHO) "$@: Generated."
 
 /etc/ssl/PiAPCA/private/PiAP_SSL.csr: /etc/ssl/PiAPCA/private/PiAP_SSL.key must_be_root
-	$(QUIET)openssl req -new -outform PEM -out /etc/ssl/PiAPCA/private/PiAP_SSL.csr -key /etc/ssl/PiAPCA/private/PiAP_SSL.key -subj "/CN=pocket.piap.local/OU=PiAP\ Root/O=PiAP\ Network/" 2>/dev/null
+	$(QUIET)openssl req -new -outform PEM -out /etc/ssl/PiAPCA/private/PiAP_SSL.csr -key /etc/ssl/PiAPCA/private/PiAP_SSL.key -subj "/CN=pocket.piap.local/OU=PiAP\ SSL/O=PiAP\ Network/" 2>/dev/null
 	$(QUITE)$(WAIT)
 	$(QUITE)$(CHOWN) $(WEB_OWN) /etc/ssl/PiAPCA/private/PiAP_SSL.csr || exit 2
 	$(QUIET)$(ECHO) "$@: Requested."

--- a/PiAP/etc/network/interfaces
+++ b/PiAP/etc/network/interfaces
@@ -64,7 +64,7 @@ iface wlan1 inet manual
 	wireless-rate 150M
 	wireless-txpower auto
 	wireless-frag auto
-	#wireless-mode Master
+	wireless-mode AP
 	hostapd /etc/hostapd/hostapd.conf
 	pre-up sysctl -w net.ipv6.conf.wlan1.disable_ipv6=1 2>/dev/null >>/dev/null ; wait ; ip link set ${IFACE:-wlan1} up ; wait ; sysctl -w net.ipv4.conf.${IFACE:-wlan1}.forwarding=1 2>/dev/null >>/dev/null || true ;
 	post-up brctl addif lan0 ${IFACE:-wlan1} 2>/dev/null || true ; ip addr del $(ip addr show ${IFACE:-wlan1} | fgrep 169.254 | grepCIDR | grepCIDR -m1) dev ${IFACE:-wlan1} 2>/dev/null || true

--- a/PiAP/etc/ssl/openssl.cnf
+++ b/PiAP/etc/ssl/openssl.cnf
@@ -698,6 +698,34 @@ oid_subj_org_type = ${ANSI_oid}.5.4.15
 #1.3.6.1.4.1.11129.2.5.1
 #2.23.140.1.2.2
 
+#alt name:
+UID = 1.3.6.1.1.1.1.0
+netgear_org = 1.3.6.1.4.1.4526
+netgear_firewall = ${netgear_org}.100.6
+fwag114 = ${netgear_firewall}.3
+fvs124g = ${netgear_firewall}.4
+fvs318v3 = ${netgear_firewall}.5
+dgfv338 = ${netgear_firewall}.6
+netgear_AP = ${netgear_org}.100.7
+netgear_WLAN = ${netgear_org}.100.8
+netgear_ngfirewall = ${netgear_org}.13
+
+# policy user notice:
+userNotice = 1.3.6.1.5.5.7.2.2
+
+# IETF RFC 2459
+# Extended Key Purposes (KPs):
+extendedKeyPurposes = 1.3.6.1.5.5.7.3
+msSmartcardlogon = 1.3.6.1.4.1.311.20.2.2
+# ipsec ike
+ipsecIKE = ${extendedKeyPurposes}.17
+# access controller
+capwapAC = ${extendedKeyPurposes}.18
+# end points
+capwapWTP = ${extendedKeyPurposes}.19
+clientsshauth = ${extendedKeyPurposes}.21
+serversshhost = ${extendedKeyPurposes}.22
+
 ####################################################################
 [ ca ]
 default_ca	= CA_default		# The default ca section


### PR DESCRIPTION
Nothing ground breaking 
- [x] status: re-tested a lot (mostly looked into backend mitigations for CVE-2017-13077 thru CVE-2017-13082 and CVE-2017-13084, and CVE-2017-13086 thru CVE-2017-13088 - i.e. KRACK reinstallation attacks on wpa2 - backends patched to latest fixes pocket, but clients need more testing)
- [x] Fixes: Minor Stability improvement for WiFi and minor ssl config enhancements