### PR TITLE
HOTFIX for version 0.3.5 ACL error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ init:
 	$(QUIET)$(ECHO) "$@: Done."
 
 install: install-dsauth install-webroot install-optroot install-wpa-actions install-hostapd-actions install-optsbin install-optbin configure-PiAP-sudoers configure-PiAP-dnsmasq install-pifi configure-PiAP-keyring must_be_root
+	$(QUITE)umask 0002
 	$(QUIET)$(MAKE) -C ./units/PiAP-python-tools/ -f Makefile install
 	$(QUITE)$(WAIT)
 	$(QUIET)$(ECHO) "$@: Done."

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -26,7 +26,10 @@ function check_depends() {
 	local DID_WORK=0
 if [[ ( $(dpkg --list | grep -E "^[i]{2}[[:space:]]+" | tr -s '\s' ' ' | cut -d \  -f 2 | grep -F -c "${THEDEPENDS}" ) -le 0 ) ]] ; then
 		message "Installing new dependencies. [\"${THEDEPENDS}\"]"
+		OLDMASK=$(umask)
+		umask 0022
 		sudo apt-get install -y "${THEDEPENDS}" 2>/dev/null || DID_WORK=1 ;
+		umask "$OLDMASK"
 		message "DONE"
 	fi
 	return $DID_WORK
@@ -208,7 +211,9 @@ message "DO NOT INTERRUPT OR POWER OFF. [CAUTION for BETA]"
 # set LED flashing here
 
 ( sudo make uninstall || ROLL_BACK=2 ) | tee -a "${PIAP_LOG_PATH}" 2>/dev/null
+umask 0002
 ( sudo make install || ROLL_BACK=2 ) | tee -a "${PIAP_LOG_PATH}" 2>/dev/null
+umask 0027
 make clean
 fi
 if [[ ( ${ROLL_BACK:-3} -gt 0 ) ]] ; then


### PR DESCRIPTION
CRITICAL HOTFIX for some testers an ACL issue is present when setting up python-tools that prevents the web-server from being able to use the unprivileged tools.