### PR TITLE
Release v0.3.9 - hotfix for #101 regression on php5 systems

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -101,9 +101,11 @@ if [[ ( ${ROLL_BACK:-1} -gt 0 ) ]] ; then
 	exit 2 ;
 fi
 
-for SOME_DEPENDS in build-essential make git gnupg2 nginx nginx-full php-fpm php7.0-xsl dnsmasq hostapd python3 python3-pip ; do
+for SOME_DEPENDS in build-essential make git gnupg2 nginx nginx-full dnsmasq hostapd python3 python3-pip ; do
 	check_depends ${SOME_DEPENDS} || exit 2 ;
 done ;
+
+check_depends php-fpm && check_depends php7.0-xsl || check_depends php5-fpm || exit 2 ;
 
 cd /tmp ;
 check_path /var/ || exit 2 ;


### PR DESCRIPTION
- [x] includes fix #102 for #101 and #100


issue was caused by `php5` being installed when `php-fpm` was not available and thus would fail to resolve to a dependancy. fix was to add explicit OR.